### PR TITLE
add middleware.ts and stubs/placeholders in each page.tsx

### DIFF
--- a/app/(auth routes)/sign-in/page.tsx
+++ b/app/(auth routes)/sign-in/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Page</h1>;
+}

--- a/app/(auth routes)/sign-up/page.tsx
+++ b/app/(auth routes)/sign-up/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Page</h1>;
+}

--- a/app/(private routes)/diary/[entryId]/page.tsx
+++ b/app/(private routes)/diary/[entryId]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Page</h1>;
+}

--- a/app/(private routes)/journey/[weekNumber]/page.tsx
+++ b/app/(private routes)/journey/[weekNumber]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Page</h1>;
+}

--- a/app/(private routes)/profile/edit/page.tsx
+++ b/app/(private routes)/profile/edit/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Page</h1>;
+}

--- a/app/(private routes)/profile/page.tsx
+++ b/app/(private routes)/profile/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Page</h1>;
+}

--- a/app/(public routes)/emotionTest/page.tsx
+++ b/app/(public routes)/emotionTest/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Page</h1>;
+}

--- a/lib/api/apiServer.ts
+++ b/lib/api/apiServer.ts
@@ -1,0 +1,4 @@
+export default function serverApi() {
+    return
+}
+// заглушка, функція має робити fetch до нашого backend і повертати response

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as setCookie from 'set-cookie-parser';
+import { checkServerSession } from "./lib/api/serverApi";
+
+const privateRoutes = [
+    '/users',
+    '/tasks',
+    '/diaries',
+    // '/auth/logout',
+    // '/auth/refresh',
+    '/weeks/private',
+    '/weeks/mom-state',
+    '/weeks/baby-state',
+];
+const publicRoutes = [
+    '/auth/register',
+    '/auth/login',
+    '/weeks/public',
+];
+
+export async function middleware(request: NextRequest) {
+    
+  const { pathname } = request.nextUrl;
+  const isPrivateRoute = privateRoutes.some((route) => pathname.startsWith(route));
+  const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route));
+    
+  const sessionId = request.cookies.get("sessionId")?.value;
+  const refreshToken = request.cookies.get("refreshToken")?.value;
+
+   if (isPrivateRoute && !sessionId) {
+    if (refreshToken) {
+      try {
+        const response = await checkServerSession();
+
+        if (response.ok) {
+          const res = NextResponse.next();
+
+          const cookiesData: string[] =
+            typeof (response.headers as any).getSetCookie === "function"
+              ? (response.headers as any).getSetCookie()
+              : setCookie.splitCookiesString(response.headers.get("set-cookie") ?? "");
+
+          const parsedCookies = setCookie.parse(cookiesData, { map: false });
+
+            for (const cookie of parsedCookies) {
+              
+            const sameSite =
+            typeof cookie.sameSite === "string"
+            ? (cookie.sameSite.toLowerCase() as "lax" | "strict" | "none")
+            : "lax";
+                
+            res.cookies.set({
+              name: cookie.name,
+              value: cookie.value,
+              path: cookie.path ?? "/",
+              httpOnly: Boolean(cookie.httpOnly),
+              secure: Boolean(cookie.secure),
+              sameSite,
+              ...(cookie.expires ? { expires: cookie.expires } : {}),
+              ...(typeof cookie.maxAge === "number" ? { maxAge: cookie.maxAge } : {}),
+              ...(cookie.domain ? { domain: cookie.domain } : {}),
+            });
+          }
+
+            return res;
+        }
+
+        return NextResponse.redirect(new URL("/auth/register", request.url));
+      } catch {
+        return NextResponse.redirect(new URL("/auth/register", request.url));
+      }
+    }
+
+    return NextResponse.redirect(new URL("/auth/register", request.url));
+  }
+
+  if (isPublicRoute && sessionId) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+
+export const config = {
+  matcher: [
+    '/users/:path*',
+    '/tasks/:path*',
+    '/diaries/:path*',
+    // '/auth/logout',
+    // '/auth/refresh',
+    '/weeks/private/:path*',
+    '/weeks/mom-state/:path*',
+    '/weeks/baby-state/:path*',
+    '/auth/register',
+    '/auth/login',
+    '/weeks/public',
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hot-toast": "^2.6.0",
+        "set-cookie-parser": "^2.7.1",
         "yup": "^1.7.0",
         "zustand": "^5.0.8"
       },
@@ -4744,6 +4745,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.6.0",
+    "set-cookie-parser": "^2.7.1",
     "yup": "^1.7.0",
     "zustand": "^5.0.8"
   },


### PR DESCRIPTION
Мідлвара перевіряє чи
1) приватний шлях і чи є валідна активна сесія, і якщо так то пропускає далі
2) приватний шдях і немає активної сесії, але є рефреш токен, у цьому випадку викликається checkServerSession що повертає нові кукі з бекенду, які прокидаємо у відповідь і користувач проходить далі
3) приватний шлях і немає нічого, і у такому випадку редірект на /auth/register
4) публічні сторінки і є активна сесія, то відбуваєьтся редірект на головну / (принаймні я розумію що має сюди редиректити, якщо треба на якусь іншу, то заміню)
5) публічні сторінки і немає сесії, то пропускає далі

Для отримання даних з бекенду додано отакі атрибути path, httpOnly, secure, sameSite, expires/maxAge, domain, і щоб з ними працювати, додано set-cookie-parser, і також в цьому випадку ці атрибути розпарсюються кожен окремо.
Просто import { parse } from "cookie" не буде працювати наскільки я зрозумів тому що призначений лише для request, а не для response. Він розбирає лише пари name=value і ігнорує інші атрибути та не вміє коректно обробляти декілька Set-Cookie одночасно.

Також Никита попросив закинути заглушки на page.tsx щоб не крашився next, я закинув